### PR TITLE
Convert Pendulum text detection to regex (partial)

### DIFF
--- a/dist/class/CardText.js
+++ b/dist/class/CardText.js
@@ -8,30 +8,33 @@ class CardText {
         this.strings.push(dbData.string1, dbData.string2, dbData.string3, dbData.string4, dbData.string5, dbData.string6, dbData.string7, dbData.string8, dbData.string9, dbData.string10, dbData.string11, dbData.string12, dbData.string13, dbData.string14, dbData.string15, dbData.string16);
     }
     getPText() {
-        const lines = this.literalDesc.split(/\r\n|\n|\r/);
-        if (lines.length > 1) {
-            let ind = lines.findIndex(l => l.indexOf("---") > -1);
-            if (ind === -1) {
-                for (let i = lines.length - 1; i >= 0; i--) {
-                    if (lines[i].indexOf("【") > -1) {
-                        ind = i;
-                        break;
-                    }
-                }
-                if (ind === -1) {
-                    return [this.literalDesc];
-                }
-                lines.splice(ind, 0, "---");
+        // english regex from https://github.com/247321453/DataEditorX/blob/master/DataEditorX/data/mse_English.txt#L25
+        const ENG_PEND_REG = /\[ Pendulum Effect \]\s*\n(?:-n\/a-)*([\S\s]*?)\n---/;
+        const ENG_MON_REG = /(Monster Effect|Flavor Text) \]\s*\n([\S\s]*)/;
+        const engPendResult = ENG_PEND_REG.exec(this.literalDesc);
+        if (engPendResult) {
+            const engMonResult = ENG_MON_REG.exec(this.literalDesc);
+            if (engMonResult) {
+                // we expect the monster text should always exist
+                // if it doesn't just continue as if not a pend and figure it out later
+                return ["Pendulum Effect", engPendResult[1], engMonResult[1], engMonResult[2]];
             }
-            const bracketReg = /\[|\]|【|】/g;
-            const head1 = lines[0].replace(bracketReg, "").trim();
-            const head2 = lines
-                .slice(ind + 1, ind + 2)[0]
-                .replace(bracketReg, "")
-                .trim();
-            // a few lines are skipped because each section has headings
-            return [head1, lines.slice(1, ind).join("\n"), head2, lines.slice(ind + 2).join("\n")];
+            console.error("Malformed Pend Monster text in English for %s!", this.name);
         }
+        // jpn regex from https://github.com/247321453/DataEditorX/blob/master/DataEditorX/data/mse_Japanese.txt#L27
+        const JPN_PEND_REG = /】[\s\S]*?\n([\S\s]*?)\n【/;
+        const JPN_MON_REG = /【([\S\s]*?[果|介|述|報])】\n([\S\s]*)/;
+        const jpnPendResult = JPN_PEND_REG.exec(this.literalDesc);
+        if (jpnPendResult) {
+            const jpnMonResult = JPN_MON_REG.exec(this.literalDesc);
+            if (jpnMonResult) {
+                return ["Ｐ効果", jpnPendResult[1], jpnMonResult[1], jpnMonResult[2]];
+            }
+            console.error("Malformed Pend Monster text in Japanese or Chinese for %s!", this.name);
+        }
+        // chinese regexes appear to be the same, but for posterity:
+        // trad: https://github.com/247321453/DataEditorX/blob/master/DataEditorX/data/mse_Chinese-Traditional.txt#L29
+        // simple: https://github.com/247321453/DataEditorX/blob/master/DataEditorX/data/mse_Chinese-Simplified.txt#L29
         return [this.literalDesc];
     }
     get desc() {

--- a/dist/class/CardText.js
+++ b/dist/class/CardText.js
@@ -9,26 +9,26 @@ class CardText {
     }
     getPText() {
         // english regex from https://github.com/247321453/DataEditorX/blob/master/DataEditorX/data/mse_English.txt#L25
-        const ENG_PEND_REG = /\[ Pendulum Effect \]\s*\n(?:-n\/a-)*([\S\s]*?)\n---/;
-        const ENG_MON_REG = /(Monster Effect|Flavor Text) \]\s*\n([\S\s]*)/;
+        const ENG_PEND_REG = /\[ Pendulum Effect \]\s*[\r\n|\r|\n](?:-n\/a-)*([\S\s]*?)[\r\n|\r|\n]---/;
+        const ENG_MON_REG = /(Monster Effect|Flavor Text) \]\s*[\r\n|\r|\n]([\S\s]*)/;
         const engPendResult = ENG_PEND_REG.exec(this.literalDesc);
         if (engPendResult) {
             const engMonResult = ENG_MON_REG.exec(this.literalDesc);
             if (engMonResult) {
                 // we expect the monster text should always exist
                 // if it doesn't just continue as if not a pend and figure it out later
-                return ["Pendulum Effect", engPendResult[1], engMonResult[1], engMonResult[2]];
+                return ["Pendulum Effect", engPendResult[1].trim(), engMonResult[1].trim(), engMonResult[2].trim()];
             }
             console.error("Malformed Pend Monster text in English for %s!", this.name);
         }
         // jpn regex from https://github.com/247321453/DataEditorX/blob/master/DataEditorX/data/mse_Japanese.txt#L27
-        const JPN_PEND_REG = /】[\s\S]*?\n([\S\s]*?)\n【/;
-        const JPN_MON_REG = /【([\S\s]*?[果|介|述|報])】\n([\S\s]*)/;
+        const JPN_PEND_REG = /】[\s\S]*?[\r\n|\r|\n]([\S\s]*?)[\r\n|\r|\n]【/;
+        const JPN_MON_REG = /[\r\n|\r|\n]【([\S\s]*?[果|介|述|報])】[\r\n|\r|\n]([\S\s]*)/;
         const jpnPendResult = JPN_PEND_REG.exec(this.literalDesc);
         if (jpnPendResult) {
             const jpnMonResult = JPN_MON_REG.exec(this.literalDesc);
             if (jpnMonResult) {
-                return ["Ｐ効果", jpnPendResult[1], jpnMonResult[1], jpnMonResult[2]];
+                return ["Ｐ効果", jpnPendResult[1].trim(), jpnMonResult[1].trim(), jpnMonResult[2].trim()];
             }
             console.error("Malformed Pend Monster text in Japanese or Chinese for %s!", this.name);
         }

--- a/lib/class/CardText.ts
+++ b/lib/class/CardText.ts
@@ -56,26 +56,26 @@ export class CardText {
 
     private getPText(): string[] {
         // english regex from https://github.com/247321453/DataEditorX/blob/master/DataEditorX/data/mse_English.txt#L25
-        const ENG_PEND_REG = /\[ Pendulum Effect \]\s*\n(?:-n\/a-)*([\S\s]*?)\n---/;
-        const ENG_MON_REG = /(Monster Effect|Flavor Text) \]\s*\n([\S\s]*)/;
+        const ENG_PEND_REG = /\[ Pendulum Effect \]\s*[\r\n|\r|\n](?:-n\/a-)*([\S\s]*?)[\r\n|\r|\n]---/;
+        const ENG_MON_REG = /(Monster Effect|Flavor Text) \]\s*[\r\n|\r|\n]([\S\s]*)/;
         const engPendResult = ENG_PEND_REG.exec(this.literalDesc);
         if (engPendResult) {
             const engMonResult = ENG_MON_REG.exec(this.literalDesc);
             if (engMonResult) {
                 // we expect the monster text should always exist
                 // if it doesn't just continue as if not a pend and figure it out later
-                return ["Pendulum Effect", engPendResult[1], engMonResult[1], engMonResult[2]];
+                return ["Pendulum Effect", engPendResult[1].trim(), engMonResult[1].trim(), engMonResult[2].trim()];
             }
             console.error("Malformed Pend Monster text in English for %s!", this.name);
         }
         // jpn regex from https://github.com/247321453/DataEditorX/blob/master/DataEditorX/data/mse_Japanese.txt#L27
-        const JPN_PEND_REG = /】[\s\S]*?\n([\S\s]*?)\n【/;
-        const JPN_MON_REG = /【([\S\s]*?[果|介|述|報])】\n([\S\s]*)/;
+        const JPN_PEND_REG = /】[\s\S]*?[\r\n|\r|\n]([\S\s]*?)[\r\n|\r|\n]【/;
+        const JPN_MON_REG = /[\r\n|\r|\n]【([\S\s]*?[果|介|述|報])】[\r\n|\r|\n]([\S\s]*)/;
         const jpnPendResult = JPN_PEND_REG.exec(this.literalDesc);
         if (jpnPendResult) {
             const jpnMonResult = JPN_MON_REG.exec(this.literalDesc);
             if (jpnMonResult) {
-                return ["Ｐ効果", jpnPendResult[1], jpnMonResult[1], jpnMonResult[2]];
+                return ["Ｐ効果", jpnPendResult[1].trim(), jpnMonResult[1].trim(), jpnMonResult[2].trim()];
             }
             console.error("Malformed Pend Monster text in Japanese or Chinese for %s!", this.name);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -351,7 +351,7 @@ describe("Testing Pendulum text", function() {
         const card = await index.getCard("オッドアイズ・ペンデュラム・ドラゴン", "ja");
         expect(card.text.ja.desc.pendHead).to.equal("Ｐ効果");
         expect(card.text.ja.desc.monsterHead).to.equal("モンスター効果");
-        expect(card.text.ja.desc.pendBody.length).to.be.below(150);
+        expect(card.text.ja.desc.pendBody.length).to.be.below(200);
         expect(card.text.ja.desc.monsterBody.length).to.be.below(50);
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -306,7 +306,7 @@ describe("Testing Pendulum text", function() {
     });
     it("Japanese Pendulum should have 4 properties", async function() {
         const card = await index.getCard("オッドアイズ・ペンデュラム・ドラゴン", "ja");
-        expect(card.text.ja.desc.pendHead).to.equal("Ｐスケール：青４／赤４");
+        expect(card.text.ja.desc.pendHead).to.equal("Ｐ効果");
         expect(card.text.ja.desc.monsterHead).to.equal("モンスター効果");
         expect(card.text.ja.desc.pendBody.length).to.be.below(150);
         expect(card.text.ja.desc.monsterBody.length).to.be.below(50);


### PR DESCRIPTION
Fix #7 
To better support edge cases and other languages, this converts the Pendulum Text detection from a messy algorithmic approach to regular expressions (based on the ones used by DataEditorX). 